### PR TITLE
Remove accent from help file name

### DIFF
--- a/doc/bepo.txt
+++ b/doc/bepo.txt
@@ -1,4 +1,4 @@
-*bépo.txt*  Plugin pour la disposition de clavier bépo
+*bepo.txt*  Plugin pour la disposition de clavier bépo
 
 Auteur: Micha Moskovic
 Licence: licence MIT


### PR DESCRIPTION
Accent in filenames causes certain configuration (like SpaceVim on my machine to abort help file generation).

It makes thus easier to install the plugin.